### PR TITLE
Fix path to image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -401,7 +401,7 @@ runs the starter microservice application. When the process completes, the follo
 If you scroll upwards in the console, you can see that Open Liberty 19.0.0.9 is in use. The output looks similar to the following
 example:
 
-image::img/guide/working-with-collections-console.png[link="/img/guide/working-with-collections-console.png" alt="Diagram shows the output from the `appsody run` command, which confirms that Open Liberty 19.0.0.9 is in use."]
+image::/img/guide/working-with-collections-console.png[link="/img/guide/working-with-collections-console.png" alt="Diagram shows the output from the `appsody run` command, which confirms that Open Liberty 19.0.0.9 is in use."]
 
 
 If you open your browser to `http://localhost:9080` you can see that the starter microservice application is running


### PR DESCRIPTION
Missing "/" causes 1 image not to load.
Fixed.

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>